### PR TITLE
feat(auth): first-class OAuth client-credentials (M2M) support

### DIFF
--- a/barndoor/sdk/__init__.py
+++ b/barndoor/sdk/__init__.py
@@ -26,6 +26,10 @@ Main Components
 - models: Pydantic models for API data structures
 """
 
+from .auth import (
+    get_client_credentials_token,
+    get_client_credentials_token_async,
+)
 from .client import BarndoorSDK
 from .exceptions import BarndoorError, ConnectionError, HTTPError
 from .models import AgentToken, ServerDetail, ServerSummary
@@ -47,6 +51,9 @@ __all__ = [
     "login_interactive",
     "ensure_server_connected",
     "make_mcp_connection_params",
+    # M2M / client-credentials helpers
+    "get_client_credentials_token",
+    "get_client_credentials_token_async",
 ]
 
 __version__ = "0.1.0"

--- a/barndoor/sdk/auth.py
+++ b/barndoor/sdk/auth.py
@@ -26,6 +26,7 @@ from .auth_store import get_oidc_config
 
 __all__ = [
     "get_client_credentials_token",
+    "get_client_credentials_token_async",
     "build_authorization_url",
     "create_authorization_request",
     "start_local_callback_server",
@@ -106,26 +107,78 @@ def get_client_credentials_token(
     -----
     The token is returned directly without any caching. For user tokens
     that should be cached, use the interactive login flow instead.
+
+    This is a synchronous call (blocking httpx). For use inside an async
+    application or alongside :class:`barndoor.sdk.BarndoorSDK`, prefer
+    :func:`get_client_credentials_token_async`.
     """
-    # Use OIDC discovery if issuer provided, otherwise fall back to domain
+    token_endpoint, data = _client_credentials_request(
+        domain=domain,
+        client_id=client_id,
+        client_secret=client_secret,
+        audience=audience,
+        issuer=issuer,
+    )
+    resp = httpx.post(token_endpoint, data=data, timeout=15)
+    resp.raise_for_status()
+    return resp.json()["access_token"]
+
+
+async def get_client_credentials_token_async(
+    *,
+    client_id: str,
+    client_secret: str,
+    audience: str,
+    issuer: str | None = None,
+    domain: str = "",
+    timeout: float = 15.0,
+) -> str:
+    """Async variant of :func:`get_client_credentials_token`.
+
+    Performs the OAuth 2.0 client-credentials grant using ``httpx.AsyncClient``
+    so it does not block the event loop. Prefer this inside async code such as
+    :class:`barndoor.sdk.BarndoorSDK` integrations.
+
+    Parameters mirror the sync helper; ``issuer`` is the OIDC issuer URL
+    (OIDC discovery resolves the token endpoint) and ``domain`` is retained
+    only for backwards compatibility.
+    """
+    token_endpoint, data = _client_credentials_request(
+        domain=domain,
+        client_id=client_id,
+        client_secret=client_secret,
+        audience=audience,
+        issuer=issuer,
+    )
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        resp = await client.post(token_endpoint, data=data)
+        resp.raise_for_status()
+        return resp.json()["access_token"]
+
+
+def _client_credentials_request(
+    *,
+    domain: str,
+    client_id: str,
+    client_secret: str,
+    audience: str,
+    issuer: str | None,
+) -> tuple[str, dict[str, str]]:
+    """Resolve the token endpoint and build the form body for the grant."""
     if issuer:
         oidc_config = get_oidc_config(issuer)
         token_endpoint = oidc_config.get("token_endpoint", f"{issuer}/oauth/token")
-    else:
+    elif domain:
         token_endpoint = f"https://{domain}/oauth/token"
+    else:
+        raise ValueError("Either 'issuer' or 'domain' must be provided")
 
-    resp = httpx.post(
-        token_endpoint,
-        data={
-            "grant_type": "client_credentials",
-            "client_id": client_id,
-            "client_secret": client_secret,
-            "audience": audience,
-        },
-        timeout=15,
-    )
-    resp.raise_for_status()
-    return resp.json()["access_token"]
+    return token_endpoint, {
+        "grant_type": "client_credentials",
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "audience": audience,
+    }
 
 
 def build_authorization_url(

--- a/barndoor/sdk/client.py
+++ b/barndoor/sdk/client.py
@@ -3,6 +3,10 @@
 from __future__ import annotations
 
 import os
+from dataclasses import dataclass
+from typing import Any
+
+from jose import jwt
 
 from ._http import HTTPClient, TimeoutConfig
 from .exceptions import ConfigurationError, HTTPError
@@ -20,6 +24,39 @@ from .validation import (
 )
 
 logger = get_logger("client")
+
+# Refresh M2M tokens this many seconds before their `exp` claim.
+_M2M_REFRESH_SKEW_SECONDS = 60
+
+
+@dataclass(frozen=True)
+class _ClientCredentials:
+    """Cached OAuth client-credentials parameters for token refresh."""
+
+    client_id: str
+    client_secret: str
+    audience: str
+    issuer: str | None = None
+    domain: str = ""
+
+
+def _token_near_expiry(token: str, skew_seconds: int) -> bool:
+    """Return True if *token*'s ``exp`` claim is within ``skew_seconds`` of now.
+
+    Returns True when the token cannot be parsed or has no ``exp`` claim so
+    that callers err on the side of refreshing rather than using a stale
+    credential.
+    """
+    import time
+
+    try:
+        claims = jwt.get_unverified_claims(token)
+    except Exception:
+        return True
+    exp = claims.get("exp")
+    if not isinstance(exp, (int, float)):
+        return True
+    return exp - time.time() <= skew_seconds
 
 
 class BarndoorSDK:
@@ -76,8 +113,80 @@ class BarndoorSDK:
         self._http = HTTPClient(timeout_config=timeout_config, max_retries=max_retries)
         self._token_validated = False
         self._closed = False
+        self._credentials: _ClientCredentials | None = None
 
         logger.info(f"Initialized BarndoorSDK for {self.base}")
+
+    @classmethod
+    async def from_client_credentials(
+        cls,
+        base_url: str,
+        *,
+        client_id: str,
+        client_secret: str,
+        audience: str,
+        issuer: str | None = None,
+        domain: str = "",
+        timeout: float = 30.0,
+        max_retries: int = 3,
+    ) -> BarndoorSDK:
+        """Build a :class:`BarndoorSDK` authenticated via OAuth client credentials.
+
+        Performs the OAuth 2.0 client-credentials grant against the Barndoor
+        auth server and returns a ready-to-use SDK instance. The credentials
+        are retained on the instance so the token can be refreshed
+        automatically when it nears expiry or when the API returns 401.
+
+        Parameters
+        ----------
+        base_url : str
+            Base URL of the Barndoor API (e.g., ``https://api.barndoor.host``).
+        client_id, client_secret : str
+            OAuth client credentials for a Barndoor M2M application.
+        audience : str
+            API audience identifier (e.g., ``https://barndoor.ai/``).
+        issuer : str, optional
+            OIDC issuer URL. Preferred over ``domain``; uses OIDC discovery
+            to locate the token endpoint.
+        domain : str, optional
+            Legacy auth domain (POSTs directly to ``https://{domain}/oauth/token``).
+            Provide either ``issuer`` or ``domain``.
+        timeout, max_retries
+            Forwarded to the underlying HTTP client.
+
+        Returns
+        -------
+        BarndoorSDK
+            An SDK instance whose ``token`` is a freshly issued M2M JWT.
+        """
+        from .auth import get_client_credentials_token_async
+
+        creds = _ClientCredentials(
+            client_id=client_id,
+            client_secret=client_secret,
+            audience=audience,
+            issuer=issuer,
+            domain=domain,
+        )
+        token = await get_client_credentials_token_async(
+            client_id=creds.client_id,
+            client_secret=creds.client_secret,
+            audience=creds.audience,
+            issuer=creds.issuer,
+            domain=creds.domain,
+        )
+        sdk = cls(
+            base_url,
+            barndoor_token=token,
+            validate_token_on_init=False,
+            timeout=timeout,
+            max_retries=max_retries,
+        )
+        sdk._credentials = creds
+        # M2M tokens come from the auth server we just called — no need to
+        # re-validate via the API on every request.
+        sdk._token_validated = True
+        return sdk
 
     async def __aenter__(self) -> BarndoorSDK:
         """Async context manager entry."""
@@ -104,12 +213,24 @@ class BarndoorSDK:
         """Make authenticated request with automatic token validation."""
         self._ensure_not_closed()
         await self.ensure_valid_token()
-
-        headers = kwargs.setdefault("headers", {})
-        headers["Authorization"] = f"Bearer {self.token}"
+        await self._maybe_refresh_m2m_token()
 
         url = f"{self.base}{path}"
-        return await self._http.request(method, url, **kwargs)
+
+        def _with_auth(kw: dict[str, Any]) -> dict[str, Any]:
+            headers = dict(kw.get("headers") or {})
+            headers["Authorization"] = f"Bearer {self.token}"
+            return {**kw, "headers": headers}
+
+        try:
+            return await self._http.request(method, url, **_with_auth(kwargs))
+        except HTTPError as exc:
+            # For M2M sessions, transparently refresh once on 401 and retry.
+            if exc.status_code == 401 and self._credentials is not None:
+                logger.info("M2M token rejected (401); refreshing and retrying once")
+                await self._refresh_m2m_token()
+                return await self._http.request(method, url, **_with_auth(kwargs))
+            raise
 
     # ---------------- Token validation -----------------
 
@@ -154,6 +275,37 @@ class BarndoorSDK:
         if not is_valid:
             raise ValueError("Token validation failed. Please re-authenticate.")
 
+        self._token_validated = True
+
+    async def _maybe_refresh_m2m_token(self) -> None:
+        """Refresh the M2M access token if it is near expiry.
+
+        No-op for SDK instances not created via :meth:`from_client_credentials`.
+        """
+        if self._credentials is None:
+            return
+        if not _token_near_expiry(self.token, _M2M_REFRESH_SKEW_SECONDS):
+            return
+        logger.debug("M2M token near expiry; refreshing")
+        await self._refresh_m2m_token()
+
+    async def _refresh_m2m_token(self) -> None:
+        """Unconditionally fetch a fresh M2M token using stored credentials."""
+        if self._credentials is None:
+            raise RuntimeError(
+                "refresh_m2m_token() called on an SDK not created via "
+                "BarndoorSDK.from_client_credentials()"
+            )
+        from .auth import get_client_credentials_token_async
+
+        creds = self._credentials
+        self.token = await get_client_credentials_token_async(
+            client_id=creds.client_id,
+            client_secret=creds.client_secret,
+            audience=creds.audience,
+            issuer=creds.issuer,
+            domain=creds.domain,
+        )
         self._token_validated = True
 
     # ---------------- Registry -----------------

--- a/examples/sample_m2m_client.py
+++ b/examples/sample_m2m_client.py
@@ -1,0 +1,45 @@
+"""Minimal machine-to-machine example using OAuth client credentials.
+
+Demonstrates the headless flow: fetch a JWT via OAuth client credentials,
+list MCP servers, and tear down cleanly. Suitable for backend services,
+scheduled jobs, or CI pipelines where no user is present to complete the
+interactive PKCE flow.
+
+Environment variables:
+
+    BARNDOOR_API_BASE_URL   e.g. https://api.barndoor.host
+    BARNDOOR_AUTH_ISSUER    e.g. https://auth.barndoor.ai/realms/barndoor
+    BARNDOOR_M2M_CLIENT_ID
+    BARNDOOR_M2M_CLIENT_SECRET
+    BARNDOOR_API_AUDIENCE   defaults to "https://barndoor.ai/"
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+from barndoor.sdk import BarndoorSDK
+
+
+async def main() -> None:
+    base_url = os.environ["BARNDOOR_API_BASE_URL"]
+    issuer = os.environ["BARNDOOR_AUTH_ISSUER"]
+    client_id = os.environ["BARNDOOR_M2M_CLIENT_ID"]
+    client_secret = os.environ["BARNDOOR_M2M_CLIENT_SECRET"]
+    audience = os.environ.get("BARNDOOR_API_AUDIENCE", "https://barndoor.ai/")
+
+    async with await BarndoorSDK.from_client_credentials(
+        base_url,
+        client_id=client_id,
+        client_secret=client_secret,
+        audience=audience,
+        issuer=issuer,
+    ) as sdk:
+        servers = await sdk.list_servers()
+        for s in servers:
+            print(f"{s.slug:30s} {s.connection_status}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_client_credentials.py
+++ b/tests/test_client_credentials.py
@@ -1,0 +1,215 @@
+"""Tests for OAuth client-credentials (M2M) support."""
+
+from __future__ import annotations
+
+import base64
+import json
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from barndoor.sdk import (
+    BarndoorSDK,
+    get_client_credentials_token,
+    get_client_credentials_token_async,
+)
+from barndoor.sdk.client import _token_near_expiry
+from barndoor.sdk.exceptions import HTTPError
+
+
+def _jwt(exp_seconds_from_now: int) -> str:
+    """Return an unsigned-looking JWT with the given ``exp`` offset."""
+    header = base64.urlsafe_b64encode(b'{"alg":"none","typ":"JWT"}').rstrip(b"=").decode()
+    payload = (
+        base64.urlsafe_b64encode(
+            json.dumps({"exp": int(time.time()) + exp_seconds_from_now}).encode()
+        )
+        .rstrip(b"=")
+        .decode()
+    )
+    return f"{header}.{payload}.sig"
+
+
+class TestTokenNearExpiry:
+    def test_token_well_within_window(self):
+        assert _token_near_expiry(_jwt(3600), skew_seconds=60) is False
+
+    def test_token_inside_skew(self):
+        assert _token_near_expiry(_jwt(30), skew_seconds=60) is True
+
+    def test_token_already_expired(self):
+        assert _token_near_expiry(_jwt(-10), skew_seconds=60) is True
+
+    def test_unparseable_token_treated_as_expired(self):
+        assert _token_near_expiry("not-a-jwt", skew_seconds=60) is True
+
+
+class TestGetClientCredentialsToken:
+    def test_sync_posts_grant_and_returns_access_token(self):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"access_token": "abc.def.ghi"}
+        mock_resp.raise_for_status.return_value = None
+
+        with (
+            patch("barndoor.sdk.auth.get_oidc_config") as mock_oidc,
+            patch("barndoor.sdk.auth.httpx.post") as mock_post,
+        ):
+            mock_oidc.return_value = {"token_endpoint": "https://issuer.test/token"}
+            mock_post.return_value = mock_resp
+
+            token = get_client_credentials_token(
+                domain="",
+                client_id="cid",
+                client_secret="csec",
+                audience="https://barndoor.ai/",
+                issuer="https://issuer.test",
+            )
+
+        assert token == "abc.def.ghi"
+        args, kwargs = mock_post.call_args
+        assert args[0] == "https://issuer.test/token"
+        assert kwargs["data"] == {
+            "grant_type": "client_credentials",
+            "client_id": "cid",
+            "client_secret": "csec",
+            "audience": "https://barndoor.ai/",
+        }
+
+    def test_sync_requires_issuer_or_domain(self):
+        with pytest.raises(ValueError, match="issuer.*domain"):
+            get_client_credentials_token(
+                domain="",
+                client_id="cid",
+                client_secret="csec",
+                audience="https://barndoor.ai/",
+            )
+
+    @pytest.mark.asyncio
+    async def test_async_uses_async_client(self):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"access_token": "tok"}
+        mock_resp.raise_for_status.return_value = None
+
+        with (
+            patch("barndoor.sdk.auth.get_oidc_config") as mock_oidc,
+            patch("barndoor.sdk.auth.httpx.AsyncClient") as mock_cls,
+        ):
+            mock_oidc.return_value = {"token_endpoint": "https://issuer.test/token"}
+            client = AsyncMock()
+            client.post.return_value = mock_resp
+            mock_cls.return_value.__aenter__.return_value = client
+
+            token = await get_client_credentials_token_async(
+                client_id="cid",
+                client_secret="csec",
+                audience="https://barndoor.ai/",
+                issuer="https://issuer.test",
+            )
+
+        assert token == "tok"
+        client.post.assert_awaited_once()
+        (call_url,) = client.post.call_args.args
+        assert call_url == "https://issuer.test/token"
+
+
+class TestBarndoorSDKFromClientCredentials:
+    @pytest.mark.asyncio
+    async def test_factory_fetches_token_and_sets_credentials(self):
+        token = _jwt(3600)
+        with patch(
+            "barndoor.sdk.auth.get_client_credentials_token_async",
+            new=AsyncMock(return_value=token),
+        ) as mock_fetch:
+            sdk = await BarndoorSDK.from_client_credentials(
+                "https://api.barndoor.host",
+                client_id="cid",
+                client_secret="csec",
+                audience="https://barndoor.ai/",
+                issuer="https://issuer.test",
+            )
+
+        try:
+            assert sdk.token == token
+            assert sdk._credentials is not None
+            assert sdk._credentials.client_id == "cid"
+            mock_fetch.assert_awaited_once()
+        finally:
+            await sdk.aclose()
+
+    @pytest.mark.asyncio
+    async def test_request_refreshes_token_near_expiry(self):
+        stale = _jwt(10)  # within default 60s skew
+        fresh = _jwt(3600)
+
+        with patch(
+            "barndoor.sdk.auth.get_client_credentials_token_async",
+            new=AsyncMock(side_effect=[stale, fresh]),
+        ):
+            sdk = await BarndoorSDK.from_client_credentials(
+                "https://api.barndoor.host",
+                client_id="cid",
+                client_secret="csec",
+                audience="https://barndoor.ai/",
+                issuer="https://issuer.test",
+            )
+
+            try:
+                with patch.object(
+                    sdk._http, "request", new=AsyncMock(return_value={"data": []})
+                ) as mock_req:
+                    await sdk._req("GET", "/api/servers")
+
+                assert sdk.token == fresh
+                assert mock_req.await_count == 1
+                _, kwargs = mock_req.call_args
+                assert kwargs["headers"]["Authorization"] == f"Bearer {fresh}"
+            finally:
+                await sdk.aclose()
+
+    @pytest.mark.asyncio
+    async def test_request_retries_once_on_401(self):
+        first = _jwt(3600)
+        second = _jwt(3600)
+
+        with patch(
+            "barndoor.sdk.auth.get_client_credentials_token_async",
+            new=AsyncMock(side_effect=[first, second]),
+        ):
+            sdk = await BarndoorSDK.from_client_credentials(
+                "https://api.barndoor.host",
+                client_id="cid",
+                client_secret="csec",
+                audience="https://barndoor.ai/",
+                issuer="https://issuer.test",
+            )
+
+            try:
+                with patch.object(
+                    sdk._http,
+                    "request",
+                    new=AsyncMock(side_effect=[HTTPError(401, "expired"), {"ok": True}]),
+                ) as mock_req:
+                    result = await sdk._req("GET", "/api/servers")
+
+                assert result == {"ok": True}
+                assert mock_req.await_count == 2
+                assert sdk.token == second
+                # Second call should carry the refreshed bearer token.
+                _, kwargs = mock_req.call_args_list[1]
+                assert kwargs["headers"]["Authorization"] == f"Bearer {second}"
+            finally:
+                await sdk.aclose()
+
+    @pytest.mark.asyncio
+    async def test_request_does_not_retry_401_without_credentials(self, sdk_client):
+        """Plain BarndoorSDK (no M2M creds) should propagate 401 as-is."""
+        with patch.object(
+            sdk_client._http,
+            "request",
+            new=AsyncMock(side_effect=HTTPError(401, "expired")),
+        ) as mock_req:
+            with pytest.raises(HTTPError):
+                await sdk_client._req("GET", "/api/servers")
+
+        assert mock_req.await_count == 1


### PR DESCRIPTION
## Summary

The SDK has had `get_client_credentials_token` since the start, but it was not a first-class flow: it wasn't re-exported from `barndoor.sdk`, was synchronous (blocks the event loop), had no tests or examples, and most importantly there was no integration with `BarndoorSDK` — callers had to fetch a token by hand and were on their own for refresh / 401 handling. This was prominent enough that it wasn't documented on https://docs.barndoor.ai/sdks/python.

This PR promotes client-credentials (M2M) to a properly supported flow alongside the interactive PKCE login.

## Changes

**`barndoor/sdk/auth.py`**
- Extract `_client_credentials_request(...)` helper (endpoint resolution + form body).
- Add `get_client_credentials_token_async(...)` using `httpx.AsyncClient` so it doesn't block the event loop.
- Sync `get_client_credentials_token` delegates to the shared helper; it now raises `ValueError` instead of silently building `https://{empty}/oauth/token` when both `issuer` and `domain` are missing.
- Add `get_client_credentials_token_async` to `__all__`.

**`barndoor/sdk/client.py`**
- New `BarndoorSDK.from_client_credentials(base_url, *, client_id, client_secret, audience, issuer=..., domain=..., timeout=..., max_retries=...)` async classmethod. Fetches the initial token and retains the credentials for later refresh.
- `_req` now refreshes the M2M token automatically when it is within 60s of `exp`, and transparently retries once on a 401 response (M2M sessions only — plain SDK instances still propagate 401 unchanged).
- Added private `_token_near_expiry` (JWT `exp` parser with safe fallback to "treat as expired") and `_ClientCredentials` dataclass.

**`barndoor/sdk/__init__.py`**
- Re-export `get_client_credentials_token` and `get_client_credentials_token_async` so callers can `from barndoor.sdk import ...` instead of reaching into `barndoor.sdk.auth`.

**Tests** (`tests/test_client_credentials.py`, 11 new cases)
- `_token_near_expiry` coverage (well-within, inside skew, expired, unparseable).
- Sync + async grant helpers (correct endpoint, correct form body, async uses `AsyncClient`, missing issuer/domain raises).
- `BarndoorSDK.from_client_credentials` end-to-end: factory wires up credentials, near-expiry refresh kicks in before the next request, 401 triggers exactly one retry with the fresh bearer token, and plain SDK clients (no creds) still propagate 401 without retrying.

**Example** (`examples/sample_m2m_client.py`)
- Minimal headless backend usage; lists MCP servers via the new factory.

## Verification

- `python -m pytest -x -q` → **122 passed** (11 new + 111 existing).
- `ruff check` + `ruff format --check` clean on all touched files.

## Follow-up

Docs PR https://github.com/barndoor-ai/docs/pull/116 will be updated to reference the new `BarndoorSDK.from_client_credentials(...)` factory once this lands.
