### PR TITLE
fix(security): remediate 9 CVEs across 6 packages

### DIFF
--- a/barndoor/sdk/auth_store.py
+++ b/barndoor/sdk/auth_store.py
@@ -6,8 +6,9 @@ import time
 from functools import lru_cache
 from pathlib import Path
 
+import jwt
 import httpx
-from jose import jwt
+from jwt import PyJWK
 
 from .exceptions import TokenError, TokenExpiredError
 from .logging import get_logger
@@ -182,19 +183,35 @@ def verify_jwt_local(token: str, issuer: str, audience: str) -> bool | None:
             logger.debug("No JWKS keys available, falling back to remote validation")
             return None
 
-        # Normalize issuer for comparison (with trailing slash)
         expected_issuer = issuer.rstrip("/") + "/"
 
-        # Verify the token
-        jwt.decode(
-            token,
-            keys,  # jose will pick the right key by 'kid'
-            audience=audience,
-            issuer=expected_issuer,
-            options={"verify_aud": True},
-        )
-        logger.debug("Token verified locally using JWKS")
-        return True
+        header = jwt.get_unverified_header(token)
+        token_kid = header.get("kid")
+
+        # Find matching key by kid, or try all keys
+        candidates = [k for k in keys if not token_kid or k.get("kid") == token_kid] or keys
+
+        last_err: Exception = ValueError("No matching JWKS key found")
+        for key_data in candidates:
+            try:
+                jwk = PyJWK(key_data)
+                jwt.decode(
+                    token,
+                    jwk.key,
+                    algorithms=[jwk.algorithm_name],
+                    audience=audience,
+                    issuer=expected_issuer,
+                )
+                logger.debug("Token verified locally using JWKS")
+                return True
+            except jwt.ExpiredSignatureError:
+                raise
+            except Exception as e:
+                last_err = e
+                continue
+
+        raise last_err
+
     except jwt.ExpiredSignatureError:
         logger.debug("Token expired (verified locally)")
         return False  # expired - let refresh path handle it
@@ -253,7 +270,13 @@ class TokenManager:
     def _should_refresh_token(self, token_data: dict) -> bool:
         """Check if token should be refreshed."""
         try:
-            claims = jwt.get_unverified_claims(token_data["access_token"])
+            token = token_data["access_token"]
+            header = jwt.get_unverified_header(token)
+            claims = jwt.decode(
+                token,
+                options={"verify_signature": False},
+                algorithms=[header.get("alg", "RS256")],
+            )
             exp = claims.get("exp", 0)
 
             # Refresh if token expires within 5 minutes

--- a/barndoor/sdk/auth_store.py
+++ b/barndoor/sdk/auth_store.py
@@ -6,8 +6,8 @@ import time
 from functools import lru_cache
 from pathlib import Path
 
-import jwt
 import httpx
+import jwt
 from jwt import PyJWK
 
 from .exceptions import TokenError, TokenExpiredError

--- a/barndoor/sdk/client.py
+++ b/barndoor/sdk/client.py
@@ -6,7 +6,7 @@ import os
 from dataclasses import dataclass
 from typing import Any
 
-from jose import jwt
+import jwt
 
 from ._http import HTTPClient, TimeoutConfig
 from .exceptions import ConfigurationError, HTTPError
@@ -50,7 +50,12 @@ def _token_near_expiry(token: str, skew_seconds: int) -> bool:
     import time
 
     try:
-        claims = jwt.get_unverified_claims(token)
+        header = jwt.get_unverified_header(token)
+        claims = jwt.decode(
+            token,
+            options={"verify_signature": False},
+            algorithms=[header.get("alg", "RS256")],
+        )
     except Exception:
         return True
     exp = claims.get("exp")

--- a/barndoor/sdk/config.py
+++ b/barndoor/sdk/config.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
+import jwt
 from dotenv import load_dotenv
-from jose import jwt
 from pydantic import BaseModel, Field
 
 # Baked-in auth configuration per environment
@@ -138,7 +138,12 @@ class BarndoorConfig(BaseModel):
         # Apply JWT-based overrides if token provided
         if token:
             try:
-                claims = jwt.get_unverified_claims(token)
+                header = jwt.get_unverified_header(token)
+                claims = jwt.decode(
+                    token,
+                    options={"verify_signature": False},
+                    algorithms=[header.get("alg", "RS256")],
+                )
 
                 # Look for organization name in user claims first,
                 # then at top level, then fallback to org_id

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "protobuf>=5.29.5",
     "pydantic>=2.10.6",
     "python-dotenv>=1.0.0",
-    "python-jose[cryptography]>=3.3.0",
+    "PyJWT[crypto]>=2.9.0",
     "typing-extensions>=4.12.2",
 ]
 
@@ -79,6 +79,15 @@ quote-style = "double"
 indent-style = "space"
 docstring-code-format = true
 line-ending = "lf"
+
+[tool.uv]
+constraint-dependencies = [
+    "urllib3>=2.7.0",
+    "python-multipart>=0.0.27",
+    "banks>2.4.1",
+    "langchain-core>1.3.2",
+    "langsmith>=0.8.0",
+]
 
 [build-system]
 requires = ["hatchling", "uv-dynamic-versioning"]

--- a/tests/test_auth_store.py
+++ b/tests/test_auth_store.py
@@ -342,7 +342,10 @@ class TestJWTVerification:
         """Test successful local JWT verification."""
         with (
             patch("barndoor.sdk.auth_store._get_jwks", return_value=mock_jwks_keys),
-            patch("barndoor.sdk.auth_store.jwt.get_unverified_header", return_value={"kid": "test-key-id", "alg": "RS256"}),
+            patch(
+                "barndoor.sdk.auth_store.jwt.get_unverified_header",
+                return_value={"kid": "test-key-id", "alg": "RS256"},
+            ),
             patch("barndoor.sdk.auth_store.PyJWK") as mock_pyjwk,
             patch("barndoor.sdk.auth_store.jwt.decode") as mock_decode,
         ):
@@ -359,7 +362,10 @@ class TestJWTVerification:
 
         with (
             patch("barndoor.sdk.auth_store._get_jwks", return_value=mock_jwks_keys),
-            patch("barndoor.sdk.auth_store.jwt.get_unverified_header", return_value={"kid": "test-key-id", "alg": "RS256"}),
+            patch(
+                "barndoor.sdk.auth_store.jwt.get_unverified_header",
+                return_value={"kid": "test-key-id", "alg": "RS256"},
+            ),
             patch("barndoor.sdk.auth_store.PyJWK") as mock_pyjwk,
             patch("barndoor.sdk.auth_store.jwt.decode") as mock_decode,
         ):

--- a/tests/test_auth_store.py
+++ b/tests/test_auth_store.py
@@ -342,8 +342,12 @@ class TestJWTVerification:
         """Test successful local JWT verification."""
         with (
             patch("barndoor.sdk.auth_store._get_jwks", return_value=mock_jwks_keys),
+            patch("barndoor.sdk.auth_store.jwt.get_unverified_header", return_value={"kid": "test-key-id", "alg": "RS256"}),
+            patch("barndoor.sdk.auth_store.PyJWK") as mock_pyjwk,
             patch("barndoor.sdk.auth_store.jwt.decode") as mock_decode,
         ):
+            mock_pyjwk.return_value.key = "mock-key"
+            mock_pyjwk.return_value.algorithm_name = "RS256"
             mock_decode.return_value = {"sub": "test-user"}
 
             result = verify_jwt_local("token", "test.auth0.com", "audience")
@@ -351,13 +355,17 @@ class TestJWTVerification:
 
     def test_verify_jwt_local_expired(self, mock_jwks_keys):
         """Test local JWT verification with expired token."""
-        from jose import jwt as jose_jwt
+        import jwt
 
         with (
             patch("barndoor.sdk.auth_store._get_jwks", return_value=mock_jwks_keys),
+            patch("barndoor.sdk.auth_store.jwt.get_unverified_header", return_value={"kid": "test-key-id", "alg": "RS256"}),
+            patch("barndoor.sdk.auth_store.PyJWK") as mock_pyjwk,
             patch("barndoor.sdk.auth_store.jwt.decode") as mock_decode,
         ):
-            mock_decode.side_effect = jose_jwt.ExpiredSignatureError("Token expired")
+            mock_pyjwk.return_value.key = "mock-key"
+            mock_pyjwk.return_value.algorithm_name = "RS256"
+            mock_decode.side_effect = jwt.ExpiredSignatureError("Token expired")
 
             result = verify_jwt_local("token", "test.auth0.com", "audience")
             assert result is False

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,15 @@ resolution-markers = [
     "python_full_version >= '3.13'",
 ]
 
+[manifest]
+constraints = [
+    { name = "banks", specifier = ">2.4.1" },
+    { name = "langchain-core", specifier = ">1.3.2" },
+    { name = "langsmith", specifier = ">=0.8.0" },
+    { name = "python-multipart", specifier = ">=0.0.27" },
+    { name = "urllib3", specifier = ">=2.7.0" },
+]
+
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
@@ -232,7 +241,7 @@ wheels = [
 
 [[package]]
 name = "banks"
-version = "2.4.1"
+version = "2.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "deprecated" },
@@ -242,9 +251,9 @@ dependencies = [
     { name = "platformdirs" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/47/5d/54c79aaaa9aa1278af24cae98d81d6ef635ad840f046bc2ccb5041ddeb1b/banks-2.4.1.tar.gz", hash = "sha256:8cbf1553f14c44d4f7e9c2064ad9212ce53ee4da000b2f8308d548b60db56655", size = 188033, upload-time = "2026-02-17T11:21:14.855Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/51/08fb68d23f4b0f6256fe85dc86e9576941550f890b079352fba719e07b39/banks-2.4.2.tar.gz", hash = "sha256:cda6013bd377ea7b701933578bfb9370fc21ad70bc13cedfc3f5cb2c034ca3dc", size = 188633, upload-time = "2026-04-27T12:15:22.021Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/5a/f38b49e8b225b0c774e97c9495e52ab9ccdf6d82bde68c513bd736820eb2/banks-2.4.1-py3-none-any.whl", hash = "sha256:40e6d9b6e9b69fb403fa31f2853b3297e4919c1b6f2179b2119d2d4473c6ed13", size = 35032, upload-time = "2026-02-17T11:21:13.236Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b6/8dc5477681b782e2f99de703e7a99828883364b9e03a60d3e2c47053d56a/banks-2.4.2-py3-none-any.whl", hash = "sha256:5fe407cc48c101f3e13d1cf732b83b8246003337612f13c0705d2e81f6faffb7", size = 35050, upload-time = "2026-04-27T12:15:20.785Z" },
 ]
 
 [[package]]
@@ -255,8 +264,8 @@ dependencies = [
     { name = "httpx", extra = ["http2"] },
     { name = "protobuf" },
     { name = "pydantic" },
+    { name = "pyjwt", extra = ["crypto"] },
     { name = "python-dotenv" },
-    { name = "python-jose", extra = ["cryptography"] },
     { name = "typing-extensions" },
 ]
 
@@ -299,8 +308,8 @@ requires-dist = [
     { name = "openai", marker = "extra == 'examples'", specifier = ">=1.61.1" },
     { name = "protobuf", specifier = ">=5.29.5" },
     { name = "pydantic", specifier = ">=2.10.6" },
+    { name = "pyjwt", extras = ["crypto"], specifier = ">=2.9.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
-    { name = "python-jose", extras = ["cryptography"], specifier = ">=3.3.0" },
     { name = "typing-extensions", specifier = ">=4.12.2" },
 ]
 provides-extras = ["examples"]
@@ -1025,18 +1034,6 @@ wheels = [
 ]
 
 [[package]]
-name = "ecdsa"
-version = "0.19.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/1f/924e3caae75f471eae4b26bd13b698f6af2c44279f67af317439c2f4c46a/ecdsa-0.19.1.tar.gz", hash = "sha256:478cba7b62555866fcb3bb3fe985e06decbdb68ef55713c4e5ab98c57d508e61", size = 201793, upload-time = "2025-03-13T11:52:43.25Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/a3/460c57f094a4a165c84a1341c373b0a4f5ec6ac244b998d5021aade89b77/ecdsa-0.19.1-py2.py3-none-any.whl", hash = "sha256:30638e27cf77b7e15c4c4cc1973720149e1033827cfd00661ca5c8cc0cdb24c3", size = 150607, upload-time = "2025-03-13T11:52:41.757Z" },
-]
-
-[[package]]
 name = "et-xmlfile"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1211,19 +1208,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b6/27/954057b0d1f53f086f681755207dda6de6c660ce133c829158e8e8fe7895/fsspec-2025.12.0.tar.gz", hash = "sha256:c505de011584597b1060ff778bb664c1bc022e87921b0e4f10cc9c44f9635973", size = 309748, upload-time = "2025-12-03T15:23:42.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/51/c7/b64cae5dba3a1b138d7123ec36bb5ccd39d39939f18454407e5468f4763f/fsspec-2025.12.0-py3-none-any.whl", hash = "sha256:8bf1fe301b7d8acfa6e8571e3b1c3d158f909666642431cc78a1b7b4dbc5ec5b", size = 201422, upload-time = "2025-12-03T15:23:41.434Z" },
-]
-
-[[package]]
-name = "google-auth"
-version = "2.47.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyasn1-modules" },
-    { name = "rsa" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/60/3c/ec64b9a275ca22fa1cd3b6e77fefcf837b0732c890aa32d2bd21313d9b33/google_auth-2.47.0.tar.gz", hash = "sha256:833229070a9dfee1a353ae9877dcd2dec069a8281a4e72e72f77d4a70ff945da", size = 323719, upload-time = "2026-01-06T21:55:31.045Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/18/79e9008530b79527e0d5f79e7eef08d3b179b7f851cfd3a2f27822fbdfa9/google_auth-2.47.0-py3-none-any.whl", hash = "sha256:c516d68336bfde7cf0da26aab674a36fedcf04b37ac4edd59c597178760c3498", size = 234867, upload-time = "2026-01-06T21:55:28.6Z" },
 ]
 
 [[package]]
@@ -1791,12 +1775,12 @@ wheels = [
 
 [[package]]
 name = "kubernetes"
-version = "34.1.0"
+version = "36.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "aiohttp" },
     { name = "certifi" },
     { name = "durationpy" },
-    { name = "google-auth" },
     { name = "python-dateutil" },
     { name = "pyyaml" },
     { name = "requests" },
@@ -1805,9 +1789,9 @@ dependencies = [
     { name = "urllib3" },
     { name = "websocket-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ef/55/3f880ef65f559cbed44a9aa20d3bdbc219a2c3a3bac4a30a513029b03ee9/kubernetes-34.1.0.tar.gz", hash = "sha256:8fe8edb0b5d290a2f3ac06596b23f87c658977d46b5f8df9d0f4ea83d0003912", size = 1083771, upload-time = "2025-09-29T20:23:49.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/59/dc635e4e9afb3884bc5c57f14fe23783e4c04601aa20b835ac75c41d1625/kubernetes-36.0.0.tar.gz", hash = "sha256:027b606bb8032e6c6464a53236bdd9bd9a94c237e1063bc45a303c25b304ced9", size = 2346728, upload-time = "2026-05-20T20:44:24.28Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/ec/65f7d563aa4a62dd58777e8f6aa882f15db53b14eb29aba0c28a20f7eb26/kubernetes-34.1.0-py2.py3-none-any.whl", hash = "sha256:bffba2272534e224e6a7a74d582deb0b545b7c9879d2cd9e4aae9481d1f2cc2a", size = 2008380, upload-time = "2025-09-29T20:23:47.684Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/d2/6f99ca9c7eb961dfdd45b9643101399a8ee20922c662c362c91e9cc7e832/kubernetes-36.0.0-py2.py3-none-any.whl", hash = "sha256:a766433357ec9f90db7565cccf52e28e7fca40b0ef366c80a6022adbc0ac0425", size = 4660469, upload-time = "2026-05-20T20:44:20.893Z" },
 ]
 
 [[package]]
@@ -1836,10 +1820,11 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.2.28"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
+    { name = "langchain-protocol" },
     { name = "langsmith" },
     { name = "packaging" },
     { name = "pydantic" },
@@ -1848,9 +1833,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/a4/317a1a3ac1df33a64adb3670bf88bbe3b3d5baa274db6863a979db472897/langchain_core-1.2.28.tar.gz", hash = "sha256:271a3d8bd618f795fdeba112b0753980457fc90537c46a0c11998516a74dc2cb", size = 846119, upload-time = "2026-04-08T18:19:34.867Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/59/de/679a53472c25860837e32c0442c962fa86e95317a36460e2c9d5c91b17c2/langchain_core-1.4.0.tar.gz", hash = "sha256:1dc341eed802ed9c117c0df3923c991e5e9e226571e5725c194eeb5bd93d1a7f", size = 920260, upload-time = "2026-05-11T18:42:35.919Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/92/32f785f077c7e898da97064f113c73fbd9ad55d1e2169cf3a391b183dedb/langchain_core-1.2.28-py3-none-any.whl", hash = "sha256:80764232581eaf8057bcefa71dbf8adc1f6a28d257ebd8b95ba9b8b452e8c6ac", size = 508727, upload-time = "2026-04-08T18:19:32.823Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/1a/86c38c27b81913a1c6c12448cab55defb5a1097c7dc9a4cea83f55477a2d/langchain_core-1.4.0-py3-none-any.whl", hash = "sha256:23cbbdb46e38ddd1dd5247e6167e96013eae74bea4c5949c550809970a9e565c", size = 548120, upload-time = "2026-05-11T18:42:33.992Z" },
 ]
 
 [[package]]
@@ -1879,6 +1864,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/cc/fd/7dee16e882c4c1577d48db174d85aa3a0ee09ba61eb6a5d41650285ca80c/langchain_openai-1.1.12.tar.gz", hash = "sha256:ccf5ef02c896f6807b4d0e51aaf678a72ce81ae41201cae8d65e11eeff9ecb79", size = 1114119, upload-time = "2026-03-23T18:59:19.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6e/a6/68fb22e3604015e6f546fa1d3677d24378b482855ae74710cbf4aec44132/langchain_openai-1.1.12-py3-none-any.whl", hash = "sha256:da71ca3f2d18c16f7a2443cc306aa195ad2a07054335ac9b0626dcae02b6a0c5", size = 88487, upload-time = "2026-03-23T18:59:17.978Z" },
+]
+
+[[package]]
+name = "langchain-protocol"
+version = "0.0.15"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4f/24/9777489d6fbbee64af0c8f96d4f840239c408cf694f3394672807dafc490/langchain_protocol-0.0.15.tar.gz", hash = "sha256:9ab2d11ee73944754f10e037e717098d3a6796f0e58afa9cadda6154e7655ade", size = 5862, upload-time = "2026-05-01T22:30:04.748Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/7a/9c97a7b9cbe4c5dc6a44cdb1545450c28f0c8ce89b9c1f0ee7fbad896263/langchain_protocol-0.0.15-py3-none-any.whl", hash = "sha256:461eb794358f83d5e42635a5797799ffec7b4702314e34edf73ac21e75d3ef79", size = 6982, upload-time = "2026-05-01T22:30:03.877Z" },
 ]
 
 [[package]]
@@ -1939,7 +1936,7 @@ wheels = [
 
 [[package]]
 name = "langsmith"
-version = "0.6.3"
+version = "0.8.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -1949,11 +1946,12 @@ dependencies = [
     { name = "requests" },
     { name = "requests-toolbelt" },
     { name = "uuid-utils" },
+    { name = "xxhash" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/da/02/ac91c812238cd232ff3270c253eea31b28253fdeb28df61571932cb26e88/langsmith-0.6.3.tar.gz", hash = "sha256:33246769c0bb24e2c17e0c34bb21931084437613cd37faf83bd0978a297b826f", size = 1739709, upload-time = "2026-01-14T19:26:23.529Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/17/eb/8883d1158c743d0aac350f09df7880714d27283497e8c80bb9fe3480f165/langsmith-0.8.5.tar.gz", hash = "sha256:3615243d99c12f4047f13042bdc05a373dce232d106a6511b3ca7b48c5af1c2c", size = 4462348, upload-time = "2026-05-15T21:31:41.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ff/11/22a56b615f1ca84f65fda68b1a53b6e2765f2bdb1c6d885793430a664bfe/langsmith-0.6.3-py3-none-any.whl", hash = "sha256:44fdf8084165513e6bede9dda715e7b460b1b3f57ac69f2ca3f03afa911233ec", size = 282991, upload-time = "2026-01-14T19:26:21.882Z" },
+    { url = "https://files.pythonhosted.org/packages/23/85/968c88a63e32a59b3e5c68afd2fe114ce0708a125db0be1a85efc25fb2ea/langsmith-0.8.5-py3-none-any.whl", hash = "sha256:efc779f9d450dcaf9d97bc8894f4926276509d6e730e05289af9a64debce06ae", size = 399564, upload-time = "2026-05-15T21:31:39.046Z" },
 ]
 
 [[package]]
@@ -3423,27 +3421,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyasn1"
-version = "0.6.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
-]
-
-[[package]]
-name = "pyasn1-modules"
-version = "0.4.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyasn1" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
-]
-
-[[package]]
 name = "pybase64"
 version = "1.4.3"
 source = { registry = "https://pypi.org/simple" }
@@ -3954,31 +3931,12 @@ wheels = [
 ]
 
 [[package]]
-name = "python-jose"
-version = "3.5.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "ecdsa" },
-    { name = "pyasn1" },
-    { name = "rsa" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/77/3a1c9039db7124eb039772b935f2244fbb73fc8ee65b9acf2375da1c07bf/python_jose-3.5.0.tar.gz", hash = "sha256:fb4eaa44dbeb1c26dcc69e4bd7ec54a1cb8dd64d3b4d81ef08d90ff453f2b01b", size = 92726, upload-time = "2025-05-28T17:31:54.288Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/c3/0bd11992072e6a1c513b16500a5d07f91a24017c5909b02c72c62d7ad024/python_jose-3.5.0-py2.py3-none-any.whl", hash = "sha256:abd1202f23d34dfad2c3d28cb8617b90acf34132c7afd60abd0b0b7d3cb55771", size = 34624, upload-time = "2025-05-28T17:31:52.802Z" },
-]
-
-[package.optional-dependencies]
-cryptography = [
-    { name = "cryptography" },
-]
-
-[[package]]
 name = "python-multipart"
-version = "0.0.22"
+version = "0.0.29"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/fe/70bd71a6738b09a0bdf6480ca6436b167469ca4578b2a0efbe390b4b0e70/python_multipart-0.0.29.tar.gz", hash = "sha256:643e93849196645e2dbdd81a0f8829a23123ad7f797a84a364c6fb3563f18904", size = 45678, upload-time = "2026-05-17T17:29:47.654Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/cb/769cfc37177252872a45a71f3fbdde9d51b471a3f3c14bfe95dde3407386/python_multipart-0.0.29-py3-none-any.whl", hash = "sha256:2ddcc971cef266225f54f552d8fa10bcfbb1f14446caec199060daac59ff2d69", size = 29640, upload-time = "2026-05-17T17:29:45.69Z" },
 ]
 
 [[package]]
@@ -4357,18 +4315,6 @@ wheels = [
 ]
 
 [[package]]
-name = "rsa"
-version = "4.9.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyasn1" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034, upload-time = "2025-04-16T09:51:18.218Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696, upload-time = "2025-04-16T09:51:17.142Z" },
-]
-
-[[package]]
 name = "ruff"
 version = "0.14.10"
 source = { registry = "https://pypi.org/simple" }
@@ -4741,11 +4687,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.3.0"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/aa/63/e53da845320b757bf29ef6a9062f5c669fe997973f966045cb019c3f4b66/urllib3-2.3.0.tar.gz", hash = "sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d", size = 307268, upload-time = "2024-12-22T07:47:30.032Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/19/4ec628951a74043532ca2cf5d97b7b14863931476d117c471e8e2b1eb39f/urllib3-2.3.0-py3-none-any.whl", hash = "sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df", size = 128369, upload-time = "2024-12-22T07:47:28.074Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **CVE-2024-23342** (`ecdsa`): All versions vulnerable — replaced `python-jose` with `PyJWT[crypto]`, eliminating `ecdsa` entirely. Migrated `jwt.decode` / `jwt.get_unverified_claims` calls in `auth_store.py`, `config.py`, and `client.py` to the PyJWT API.
- **CVE-2025-66418 / CVE-2025-66471 / CVE-2026-21441 / CVE-2026-44431** (`urllib3`): Added `urllib3>=2.7.0` constraint; lock upgraded 2.3.0 → 2.7.0.
- **CVE-2026-42561** (`python-multipart`): Added `python-multipart>=0.0.27` constraint; lock upgraded 0.0.22 → 0.0.29.
- **CVE-2026-44209** (`banks`): Added `banks>2.4.1` constraint; lock upgraded 2.4.1 → 2.4.2.
- **CVE-2026-44843** (`langchain-core`): Added `langchain-core>1.3.2` constraint; lock upgraded 1.2.28 → 1.4.0.
- **CVE-2026-45134** (`langsmith`): Added `langsmith>=0.8.0` constraint; lock upgraded 0.6.3 → 0.8.5.

## Test plan

- [ ] Run `uv sync` and verify no install errors
- [ ] Run test suite: `uv run pytest`
- [ ] Confirm `ecdsa` and `python-jose` are absent: `uv pip list | grep -E "ecdsa|python-jose"`
- [ ] Confirm JWT auth flows still work end-to-end (login, token refresh, local JWKS verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)