### PR TITLE
chore(ci): pin actions to Node 24 SHAs (BCP-2208)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,12 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: 0.8.22
 
@@ -24,7 +24,7 @@ jobs:
         run: uv sync --frozen --all-extras --dev --python 3.13
 
       - name: Run pre-commit on all files
-        uses: pre-commit/action@v3.0.0
+        uses: pre-commit/action@646c83fcd040023954eafda54b4db0192ce70507 # v3.0.0
         with:
           extra_args: --all-files --verbose
         env:
@@ -41,10 +41,10 @@ jobs:
         python-version: [ '3.10', '3.11', '3.12', '3.13' ]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: 0.8.22
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: 0.8.22
 
@@ -26,7 +26,7 @@ jobs:
         run: uv build
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-dists
           path: dist/
@@ -37,7 +37,7 @@ jobs:
     environment: release
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-dists
           path: dist/


### PR DESCRIPTION
## What & why

Node.js 20 is deprecated for GitHub Actions ([BCP-2208](https://barndoor-team.atlassian.net/browse/BCP-2208)). Pins the JS actions in `ci.yml` and `release.yml` to commit SHAs of their Node 24 releases (per Tim's "pin git sha" note). Versions match those already vetted in `bdai-platform`.

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `@v4` | `de0fac2e` # v6.0.2 |
| `astral-sh/setup-uv` | `@v5` | `08807647` # v8.1.0 |
| `actions/upload-artifact` | `@v4` | `043fb46d` # v7.0.1 |
| `actions/download-artifact` | `@v4` | `3e5f45b2` # v8.0.1 |
| `pre-commit/action` | `@v3.0.0` | `646c83fc` # v3.0.0 (SHA pin) |

`pypa/gh-action-pypi-publish` deliberately left on `release/v1` — SHA-pinning is discouraged for the Trusted Publishing flow.

## Validation
- `actionlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)