### PR TITLE
fix(security): document CVE-2026-45829 (chromadb ChromaToast), stage forward constraint

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,3 +15,23 @@ If you believe you have discovered a bug, defect, flaw or vulnerability in this 
     - Submit your findings to our [Vulnerability Disclosure Program](https://docs.google.com/forms/d/e/1FAIpQLScKkUDCkghzOyg7cMBKcJYewTcOvJkY9G0KCaL5sREmEow8Vw/viewform?usp=header)
 
 --,  with as much information as possible.
+
+## Known Issues
+
+### CVE-2026-45829 — ChromaDB "ChromaToast" pre-auth RCE (transitive, not exploitable here)
+
+- **Package:** `chromadb` (affected `>= 1.0.0, <= 1.5.9`), CVSS v4.0 10.0.
+- **Status:** No fixed release exists upstream as of 2026-06-07 — the latest
+  published version (`1.5.9`) is still vulnerable ([chroma-core/chroma#6717](https://github.com/chroma-core/chroma/issues/6717),
+  [NVD](https://nvd.nist.gov/vuln/detail/CVE-2026-45829)).
+- **Exposure in this SDK:** `chromadb` is **not** a runtime dependency of the
+  `barndoor` package. It is pulled in transitively by `crewai`, which appears
+  only under the optional `examples` extra and the `dev` dependency group.
+- **Why it is not exploitable here:** the vulnerability is reachable only when
+  running ChromaDB's Python FastAPI **server**
+  (`chromadb.server.fastapi.FastAPI`). This project never starts that server;
+  `crewai` uses `chromadb` purely as an embedded client. The published SDK
+  ships no `chromadb` attack surface.
+- **Remediation plan:** a forward-looking constraint is staged (commented out)
+  in `pyproject.toml` under `[tool.uv] constraint-dependencies` and will be
+  enabled as soon as a patched `chromadb` (`> 1.5.9`) is published.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,13 @@ constraint-dependencies = [
     "banks>2.4.1",
     "langchain-core>1.3.2",
     "langsmith>=0.8.0",
+    # CVE-2026-45829 ("ChromaToast", CVSS 10.0): pre-auth RCE in chromadb's
+    # FastAPI server, affecting >=1.0.0,<=1.5.9. No patched release exists yet
+    # (latest published is 1.5.9). chromadb reaches this project only
+    # transitively via crewai (examples/dev only) and the vulnerable FastAPI
+    # server is never run here, so it is not exploitable. Enable the constraint
+    # below once a fixed chromadb (>1.5.9) ships. See SECURITY.md.
+    # "chromadb>1.5.9",
 ]
 
 [build-system]


### PR DESCRIPTION
## Summary

Compliance annotation - fix not yet available.

[CVE-2026-45829](https://nvd.nist.gov/vuln/detail/CVE-2026-45829) ("ChromaToast", CVSS v4.0 **10.0**) is a pre-authentication RCE in ChromaDB's Python FastAPI server, affecting `chromadb >= 1.0.0, <= 1.5.9`.

Unlike #81, **there is no version bump that fixes this today:**

- The latest published `chromadb` is `1.5.9` — the top of the vulnerable range — and it is still vulnerable. Upstream issue [chroma-core/chroma#6717](https://github.com/chroma-core/chroma/issues/6717) is open; no patched release exists.
- A `chromadb>1.5.9` constraint would make `uv lock` unsolvable right now.

**Exposure in this SDK is non-exploitable:**

- `chromadb` is **not** a runtime dependency of `barndoor`. It is pulled in transitively by `crewai`, which appears only under the optional `examples` extra and the `dev` group.
- The vulnerable surface is *running* ChromaDB's FastAPI server (`chromadb.server.fastapi.FastAPI`). This project never does that; `crewai` uses `chromadb` as an embedded client. The published SDK ships no ChromaToast attack surface.

## Changes

- **SECURITY.md** — document CVE-2026-45829 as a known, non-exploitable transitive exposure with no upstream fix yet.
- **pyproject.toml** — stage a commented-out `chromadb>1.5.9` constraint under `[tool.uv] constraint-dependencies`, ready to enable the moment a patched release ships.

## Verification

- `uv lock --check` passes — dependency resolution is unchanged (`uv.lock` untouched).
- `pyproject.toml` validates as TOML.

## Follow-up

Re-enable the staged constraint and re-lock once `chromadb > 1.5.9` is published with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)