### PR TITLE
fix(security): remediate CVE-2026-28684 (python-dotenv) and CVE-2026-22701 (filelock)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,6 +18,16 @@ If you believe you have discovered a bug, defect, flaw or vulnerability in this 
 
 ## Known Issues
 
+### CVE-2026-28684 — python-dotenv environment variable injection (remediated)
+
+- **Package:** `python-dotenv` (affected `< 1.2.2`), see [NVD](https://nvd.nist.gov/vuln/detail/CVE-2026-28684).
+- **Status:** Fixed in `python-dotenv >= 1.2.2`. This project now requires
+  `python-dotenv>=1.2.2` in `[project] dependencies`; the lock resolves to `1.2.2`.
+- **Exposure in this SDK:** `python-dotenv` is a direct runtime dependency used
+  to load environment variables (API keys, configuration) from `.env` files.
+- **Remediation:** lower bound bumped from `>=1.0.0` to `>=1.2.2` in
+  `pyproject.toml`; lock file updated to `1.2.2`.
+
 ### CVE-2026-25087 — pyarrow arbitrary code execution via IPC (remediated)
 
 - **Package:** `pyarrow` (affected `>= 15.0.0, < 23.0.1`), see [NVD](https://nvd.nist.gov/vuln/detail/CVE-2026-25087).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,6 +28,19 @@ If you believe you have discovered a bug, defect, flaw or vulnerability in this 
 - **Remediation:** lower bound bumped from `>=1.0.0` to `>=1.2.2` in
   `pyproject.toml`; lock file updated to `1.2.2`.
 
+### CVE-2026-22701 — filelock path traversal / symlink attack (remediated)
+
+- **Package:** `filelock` (affected `< 3.20.3`), see [NVD](https://nvd.nist.gov/vuln/detail/CVE-2026-22701).
+- **Status:** Fixed in `filelock >= 3.20.3`. This project now pins
+  `filelock>=3.20.3` via `[tool.uv] constraint-dependencies`; the lock resolves
+  to `3.29.4`.
+- **Exposure in this SDK:** `filelock` is a transitive dependency pulled in via
+  `huggingface-hub` and `virtualenv`, both of which appear only under the
+  optional `examples` extra and the `dev` dependency group. It is not a runtime
+  dependency of the published `barndoor` package.
+- **Remediation:** constraint `filelock>=3.20.3` added to `pyproject.toml`;
+  lock file updated to `3.29.4`.
+
 ### CVE-2026-25087 — pyarrow arbitrary code execution via IPC (remediated)
 
 - **Package:** `pyarrow` (affected `>= 15.0.0, < 23.0.1`), see [NVD](https://nvd.nist.gov/vuln/detail/CVE-2026-25087).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "httpx[http2]>=0.27.2",
     "protobuf>=5.29.5",
     "pydantic>=2.10.6",
-    "python-dotenv>=1.0.0",
+    "python-dotenv>=1.2.2",
     "PyJWT[crypto]>=2.9.0",
     "typing-extensions>=4.12.2",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,10 @@ constraint-dependencies = [
     # CVE-2026-25087: arbitrary code execution via malicious IPC payloads in
     # pyarrow, affecting >=15.0.0,<23.0.1. Fixed in 23.0.1. See SECURITY.md.
     "pyarrow>=23.0.1",
+    # CVE-2026-22701: filelock path traversal / symlink attack, affecting
+    # <3.20.3. Fixed in 3.20.3. filelock reaches this project transitively via
+    # huggingface-hub and virtualenv (examples/dev only). See SECURITY.md.
+    "filelock>=3.20.3",
     # CVE-2026-45829 ("ChromaToast", CVSS 10.0): pre-auth RCE in chromadb's
     # FastAPI server, affecting >=1.0.0,<=1.5.9. No patched release exists yet
     # (latest published is 1.5.9). chromadb reaches this project only

--- a/uv.lock
+++ b/uv.lock
@@ -310,7 +310,7 @@ requires-dist = [
     { name = "protobuf", specifier = ">=5.29.5" },
     { name = "pydantic", specifier = ">=2.10.6" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.9.0" },
-    { name = "python-dotenv", specifier = ">=1.0.0" },
+    { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "typing-extensions", specifier = ">=4.12.2" },
 ]
 provides-extras = ["examples"]
@@ -3924,11 +3924,11 @@ wheels = [
 
 [[package]]
 name = "python-dotenv"
-version = "1.1.1"
+version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f6/b0/4bc07ccd3572a2f9df7e6782f52b0c6c90dcbb803ac4a167702d7d0dfe1e/python_dotenv-1.1.1.tar.gz", hash = "sha256:a8a6399716257f45be6a007360200409fce5cda2661e3dec71d23dc15f6189ab", size = 41978, upload-time = "2025-06-24T04:21:07.341Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/ed/539768cf28c661b5b068d66d96a2f155c4971a5d55684a514c1a0e0dec2f/python_dotenv-1.1.1-py3-none-any.whl", hash = "sha256:31f23644fe2602f88ff55e1f5c79ba497e01224ee7737937930c448e4d0e24dc", size = 20556, upload-time = "2025-06-24T04:21:06.073Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -11,6 +11,7 @@ resolution-markers = [
 [manifest]
 constraints = [
     { name = "banks", specifier = ">2.4.1" },
+    { name = "filelock", specifier = ">=3.20.3" },
     { name = "langchain-core", specifier = ">1.3.2" },
     { name = "langsmith", specifier = ">=0.8.0" },
     { name = "pyarrow", specifier = ">=23.0.1" },
@@ -1057,11 +1058,11 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.20.2"
+version = "3.29.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c1/e0/a75dbe4bca1e7d41307323dad5ea2efdd95408f74ab2de8bd7dba9b51a1a/filelock-3.20.2.tar.gz", hash = "sha256:a2241ff4ddde2a7cebddf78e39832509cb045d18ec1a09d7248d6bfc6bfbbe64", size = 19510, upload-time = "2026-01-02T15:33:32.582Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/dc/be6cbe99670cd6e4ad387123647cb08e0c32975e223f82551e914c5568a6/filelock-3.29.4.tar.gz", hash = "sha256:10cdb3656fc44541cdf30652a93fb10ec6b05325620eb316bd26893e4201538a", size = 63028, upload-time = "2026-06-13T16:12:00.744Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/30/ab407e2ec752aa541704ed8f93c11e2a5d92c168b8a755d818b74a3c5c2d/filelock-3.20.2-py3-none-any.whl", hash = "sha256:fbba7237d6ea277175a32c54bb71ef814a8546d8601269e1bfc388de333974e8", size = 16697, upload-time = "2026-01-02T15:33:31.133Z" },
+    { url = "https://files.pythonhosted.org/packages/13/37/a065dc3bd6e49423a6532c642ca7378d3f467b1ef44c2800c937af7f9739/filelock-3.29.4-py3-none-any.whl", hash = "sha256:dac1648087d5115554850d113e7dd8c83ab2d38e3435dde2d4f163847e57b767", size = 42757, upload-time = "2026-06-13T16:11:59.582Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **CVE-2026-28684** (`python-dotenv`): bumps lower bound from `>=1.0.0` to `>=1.2.2`; lock resolves to `1.2.2`
- **CVE-2026-22701** (`filelock`): adds constraint `filelock>=3.20.3`; lock resolves to `3.29.4` (transitive via `huggingface-hub` and `virtualenv`, examples/dev only)

## Test plan

- [ ] `uv lock` resolves cleanly with no conflicts
- [ ] `python-dotenv` resolves to `>= 1.2.2`
- [ ] `filelock` resolves to `>= 3.20.3`
- [ ] `uv run pytest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)