### PR TITLE
fix(security): add defensive pyasn1>=0.6.4 constraint (BCP-3713)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -57,6 +57,22 @@ If you believe you have discovered a bug, defect, flaw or vulnerability in this 
 - **Remediation:** constraint `nltk>=3.10.0` added to `pyproject.toml`; lock
   file updated `3.9.4` -> `3.10.3`. Tracked in BCP-3713.
 
+### CVE-2026-59884 et al. — pyasn1 ASN.1 parsing vulnerabilities (remediated)
+
+- **Package:** `pyasn1` (affected `< 0.6.4`). Covers CVE-2026-59884 (integer
+  overflow in tag decoding), CVE-2026-59885 (unbounded memory allocation via
+  crafted indefinite-length encodings), and CVE-2026-59886 (stack exhaustion
+  through deeply nested constructed types).
+- **Status:** All fixed in `pyasn1 >= 0.6.4`. This project pins `pyasn1>=0.6.4`
+  via `[tool.uv] constraint-dependencies` as a defensive measure.
+- **Exposure in this SDK:** `pyasn1` previously reached this project transitively
+  via `cryptography` (pulled in by `PyJWT[crypto]`) but is **no longer in the
+  resolved dependency tree** as of the current lock file. The constraint is
+  retained so that if a future dependency change reintroduces `pyasn1`, it will
+  resolve to a safe version.
+- **Remediation:** constraint `pyasn1>=0.6.4` added to `pyproject.toml`. No lock
+  file change required (package not in tree). Tracked in BCP-3713.
+
 ### GHSA-xf7x-x43h-rpqh — json-repair circular `$ref` unbounded CPU DoS (remediated)
 
 - **Package:** `json-repair` (affected `< 0.60.1`), see

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,14 @@ constraint-dependencies = [
     # langchain-mcp-adapters, and llama-index-tools-mcp (examples/dev only).
     # See SECURITY.md.
     "mcp>=1.28.1",
+    # CVE-2026-59884, CVE-2026-59885, CVE-2026-59886: ASN.1 parsing
+    # vulnerabilities in pyasn1 — integer overflow in tag decoding, unbounded
+    # memory allocation via crafted indefinite-length encodings, and stack
+    # exhaustion through deeply nested constructed types — affecting <0.6.4.
+    # Fixed in 0.6.4. pyasn1 previously reached this project transitively via
+    # cryptography (PyJWT[crypto]) but is no longer in the resolved dependency
+    # tree; this constraint is retained defensively. See SECURITY.md.
+    "pyasn1>=0.6.4",
     # CVE-2026-54058, CVE-2026-54059, CVE-2026-54060, CVE-2026-55379,
     # CVE-2026-55380, CVE-2026-55798, CVE-2026-59197, CVE-2026-59198,
     # CVE-2026-59199, CVE-2026-59200, CVE-2026-59203, CVE-2026-59204,

--- a/uv.lock
+++ b/uv.lock
@@ -19,6 +19,7 @@ constraints = [
     { name = "nltk", specifier = ">=3.10.0" },
     { name = "pillow", specifier = ">=12.3.0" },
     { name = "pyarrow", specifier = ">=23.0.1" },
+    { name = "pyasn1", specifier = ">=0.6.4" },
     { name = "python-multipart", specifier = ">=0.0.27" },
     { name = "urllib3", specifier = ">=2.7.0" },
 ]


### PR DESCRIPTION
## Summary

Adds a defensive `pyasn1>=0.6.4` constraint to `[tool.uv] constraint-dependencies` to remediate the remaining pyasn1 CVEs flagged in [BCP-3713](https://barndoor-team.atlassian.net/browse/BCP-3713).

## CVEs addressed

| CVE | Description | Fixed in |
|-----|-------------|----------|
| CVE-2026-59884 | Integer overflow in ASN.1 tag decoding | pyasn1 ≥ 0.6.4 |
| CVE-2026-59885 | Unbounded memory allocation via crafted indefinite-length encodings | pyasn1 ≥ 0.6.4 |
| CVE-2026-59886 | Stack exhaustion through deeply nested constructed types | pyasn1 ≥ 0.6.4 |

## Context

`pyasn1` previously reached this project transitively via `cryptography` (pulled in by `PyJWT[crypto]`) but is **no longer in the resolved dependency tree**. The constraint is added defensively — following the established pattern for pillow, nltk, filelock, pyarrow, etc. — so that if a future dependency change reintroduces `pyasn1`, it will resolve to a safe version.

The pillow and nltk CVEs from BCP-3713 were already remediated in #129.

## Changes

- **pyproject.toml**: Added `pyasn1>=0.6.4` to `[tool.uv] constraint-dependencies` with inline CVE documentation
- **uv.lock**: Regenerated (only change is the new constraint entry — no package version changes since pyasn1 is not in the tree)
- **SECURITY.md**: Added advisory entry for CVE-2026-59884/59885/59886

## Testing

- `uv lock --check` ✅
- `pytest tests/` — 122 tests passed ✅
- Pre-commit hooks all passed ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)